### PR TITLE
#369: Update parser to accept gitlab urls. Refactor to use URL js interfaces instead of deprecated url.parse()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,15 @@
-type GithubParseResult = URL & {
+type GitParseResult = URL & {
   owner: string;
   name: string;
-  branchAndDirectory?: string[];
+  branchAndDirectory: string[];
 };
 
-declare function simpleGithubParse(str: string): GithubParseResult;
+declare function simpleGithubParse(str: string): GitParseResult;
+declare function simpleGitParse(str: string): GitParseResult;
 
-declare namespace simpleGithubParse {
-  export type SimpleGithubParseResult = GithubParseResult;
+declare namespace simpleGitParse {
+  export type SimpleGithubParseResult = GitParseResult;
+  export type SimpleGitParseResult = GitParseResult;
 }
 
-export = simpleGithubParse;
+export = simpleGitParse;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "branch",
     "git",
     "github",
+    "gitlab",
+    "bitbucket",
     "match",
     "parse",
     "regex",


### PR DESCRIPTION
### Changes

- Parse GitLab urls as well as GitHub urls
- Replace 'github' mentions with 'git' mentions. TS types have still old types for compatibility
- Refactor from deprecated [url.parse](https://nodejs.org/docs/latest-v12.x/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost) method to [URL](https://nodejs.org/docs/latest-v12.x/api/url.html#url_new_url_input_base) object